### PR TITLE
ブロックの列を1列増やす

### DIFF
--- a/game.js
+++ b/game.js
@@ -27,8 +27,8 @@ const paddle = {
 
 // ブロックの設定
 const brickRowCount = 5;
-const brickColumnCount = 9;
-const brickWidth = 75;
+const brickColumnCount = 10;
+const brickWidth = 65;
 const brickHeight = 20;
 const brickPadding = 10;
 const brickOffsetTop = 60;
@@ -273,4 +273,4 @@ function draw() {
 
 // 初期化処理
 initBricks();
-draw(); 
+draw();


### PR DESCRIPTION
## 実装内容
- ブロックの列（縦の列）を9列から10列に増やしました
- ブロックの幅を75pxから65pxに調整し、キャンバス内に適切に表示されるようにしました

## 変更点
- game.jsファイル内の`brickColumnCount`変数の値を9から10に変更
- `brickWidth`変数の値を75から65に変更してレイアウト調整

## 動作確認
- ブロックが10列表示されることを確認
- 画面内に適切に収まり、視覚的に問題がないことを確認
- ゲームプレイに支障がないことを確認

Closes #1